### PR TITLE
Updated for pfSense 2.4.4 IPv4+6 TCP+UDP

### DIFF
--- a/pfSense Extractors.json
+++ b/pfSense Extractors.json
@@ -7,7 +7,7 @@
         {
           "type": "csv",
           "config": {
-            "column_header": "RuleNumber,SubRuleNumber,Anchor,Tracker,Interface,Reason,Action,Direction,IPVersion,TOS,ECN,TTL,ID,Offset,Flags,ProtocolID,Protocol,Length,SourceIP,DestIP,SourcePort,DestPort,DataLength,TCPFlags,Sequence,ACK,Window,URG,Options"
+            "column_header": "RuleNumber,SubRuleNumber,Anchor,Tracker,Interface,Reason,Action,Direction,IPVersion,TOS,ECN,TTL,ID,Offset,Flags,ProtocolID,Protocol,Length,SourceIP,DestIP,SourcePort,DestPort,DataLength,TCP Flags,Sequence,umber,ACK,Window,URG,Options"
           }
         }
       ],
@@ -19,10 +19,8 @@
         "regex_value": "^filterlog:\\s+(.*)$"
       },
       "condition_type": "regex",
-      "condition_value": "^filterlog:\\s+.*,(in|out),4,.*,tcp,.*$"
+      "condition_value": "^filterlog:\\s+.*,(in|out),4,.*,[tT][cC][pP],.*$"
     },
-	
-	
     {
       "title": "pfSense filterlog: IPv4 UDP",
       "extractor_type": "regex",
@@ -30,7 +28,7 @@
         {
           "type": "csv",
           "config": {
-            "column_header": "RuleNumber,SubRuleNumber,Anchor,Tracker,Interface,Reason,Action,Direction,IPVersion,TOS,ECN,TTL,ID,Offset,Flags,ProtocolID,Protocol,Length,SourceIP,DestIP,SourcePort,DestPort,DataLength"
+            "column_header": "RuleNumber,SubRuleNumber,Anchor,Tracker,Interface,Reason,Action,Direction,IPVersion,TOS,ECN,TTL,ID,Offset,Flags,ProtocolID,Protocol,Length,SourceIP,DestIP,SourcePort,DestPort,DataLength,TCP Flags,Sequence,umber,ACK,Window,URG,Options"
           }
         }
       ],
@@ -42,10 +40,8 @@
         "regex_value": "^filterlog:\\s+(.*)$"
       },
       "condition_type": "regex",
-      "condition_value": "^filterlog:\\s+.*,(in|out),4,.*,UDP,.*$"
+      "condition_value": "^filterlog:\\s+.*,(in|out),4,.*,[uU][dD][pP],.*$"
     },
-	
-	
     {
       "title": "pfSense filterlog: IPv6 TCP",
       "extractor_type": "regex",
@@ -53,7 +49,7 @@
         {
           "type": "csv",
           "config": {
-            "column_header": "RuleNumber,SubRuleNumber,Anchor,Tracker,Interface,Reason,Action,Direction,IPVersion,Class,FlowLabel,HopLimit,Protocol,ProtocolID,Length,SourceIP,DestIP,SourcePort,DestPort,DataLength,TCPFlags,Sequence,ACK,Window,URG,Options"
+            "column_header": "RuleNumber,SubRuleNumber,Anchor,Tracker,Interface,Reason,Action,Direction,IPVersion,TOS,ECN,TTL,14,15,16,17,Protocol,ProtocolID,Length,SourceIP,DestIP,SourcePort,DestPort,DataLength,TCP Flags,Sequence Number,ACK,Window,URG,Options"
           }
         }
       ],
@@ -65,10 +61,8 @@
         "regex_value": "^filterlog:\\s+(.*)$"
       },
       "condition_type": "regex",
-      "condition_value": "^filterlog:\\s+.*,(in|out),6,.*,tcp,.*$"
+      "condition_value": "^filterlog:\\s+.*,(in|out),6,.*,[tT][cC][pP],.*$"
     },
-	
-	
     {
       "title": "pfSense filterlog: IPv6 UDP",
       "extractor_type": "regex",
@@ -76,7 +70,7 @@
         {
           "type": "csv",
           "config": {
-            "column_header": "RuleNumber,SubRuleNumber,Anchor,Tracker,Interface,Reason,Action,Direction,IPVersion,Class,FlowLabel,HopLimit,Protocol,ProtocolID,Length,SourceIP,DestIP,SourcePort,DestPort,DataLength"
+            "column_header": "RuleNumber,SubRuleNumber,Anchor,Tracker,Interface,Reason,Action,Direction,IPVersion,TOS,ECN,TTL,14,15,16,17,Protocol,ProtocolID,Length,SourceIP,DestIP,SourcePort,DestPort,DataLength,TCP Flags,Sequence Number,ACK,Window,URG,Options"
           }
         }
       ],
@@ -88,192 +82,8 @@
         "regex_value": "^filterlog:\\s+(.*)$"
       },
       "condition_type": "regex",
-      "condition_value": "^filterlog:\\s+.*,(in|out),6,.*,UDP,.*$"
-    },
-	
-	
-    {
-      "title": "pfSense filterlog: IPv4 ICMP Echo",
-      "extractor_type": "regex",
-      "converters": [
-        {
-          "type": "csv",
-          "config": {
-            "column_header": "RuleNumber,SubRuleNumber,Anchor,Tracker,Interface,Reason,Action,Direction,IPVersion,TOS,ECN,TTL,ID,Offset,Flags,ProtocolID,Protocol,Length,SourceIP,DestIP,ICMP_Type,ICMP_ID,ICMP_Sequence"
-          }
-        }
-      ],
-      "order": 0,
-      "cursor_strategy": "copy",
-      "source_field": "message",
-      "target_field": "FilterData",
-      "extractor_config": {
-        "regex_value": "^filterlog:\\s+(.*)$"
-      },
-      "condition_type": "regex",
-      "condition_value": "^filterlog:\\s+.*,(in|out),4,.*,icmp,.*,(request|reply),.*$"
-    },
-	
-	
-    {
-      "title": "pfSense filterlog: IPv4 ICMP Unreachable Protocol",
-      "extractor_type": "regex",
-      "converters": [
-        {
-          "type": "csv",
-          "config": {
-            "column_header": "RuleNumber,SubRuleNumber,Anchor,Tracker,Interface,Reason,Action,Direction,IPVersion,TOS,ECN,TTL,ID,Offset,Flags,ProtocolID,Protocol,Length,SourceIP,DestIP,ICMP_Type,ICMP_DestIP,ICMP_ProtocolID"
-          }
-        }
-      ],
-      "order": 0,
-      "cursor_strategy": "copy",
-      "source_field": "message",
-      "target_field": "FilterData",
-      "extractor_config": {
-        "regex_value": "^filterlog:\\s+(.*)$"
-      },
-      "condition_type": "regex",
-      "condition_value": "^filterlog:\\s+.*,(in|out),4,.*,icmp,.*,unreachproto,.*$"
-    },
-	
-	
-    {
-      "title": "pfSense filterlog: IPv4 ICMP Unreachable Port",
-      "extractor_type": "regex",
-      "converters": [
-        {
-          "type": "csv",
-          "config": {
-            "column_header": "RuleNumber,SubRuleNumber,Anchor,Tracker,Interface,Reason,Action,Direction,IPVersion,TOS,ECN,TTL,ID,Offset,Flags,ProtocolID,Protocol,Length,SourceIP,DestIP,ICMP_Type,ICMP_DestIP,ICMP_ProtocolID,ICMP_Port"
-          }
-        }
-      ],
-      "order": 0,
-      "cursor_strategy": "copy",
-      "source_field": "message",
-      "target_field": "FilterData",
-      "extractor_config": {
-        "regex_value": "^filterlog:\\s+(.*)$"
-      },
-      "condition_type": "regex",
-      "condition_value": "^filterlog:\\s+.*,(in|out),4,.*,icmp,.*,unreachport,.*$"
-    },
-	
-	
-    {
-      "title": "pfSense filterlog: IPv4 ICMP Unreachable Other",
-      "extractor_type": "regex",
-      "converters": [
-        {
-          "type": "csv",
-          "config": {
-            "column_header": "RuleNumber,SubRuleNumber,Anchor,Tracker,Interface,Reason,Action,Direction,IPVersion,TOS,ECN,TTL,ID,Offset,Flags,ProtocolID,Protocol,Length,SourceIP,DestIP,ICMP_Type,ICMP_Description"
-          }
-        }
-      ],
-      "order": 0,
-      "cursor_strategy": "copy",
-      "source_field": "message",
-      "target_field": "FilterData",
-      "extractor_config": {
-        "regex_value": "^filterlog:\\s+(.*)$"
-      },
-      "condition_type": "regex",
-      "condition_value": "^filterlog:\\s+.*,(in|out),4,.*,icmp,.*,(unreach|timexceed|paramprob|redirect|maskreply),.*$"
-    },
-	
-	
-    {
-      "title": "pfSense filterlog: IPv4 ICMP Need Frag",
-      "extractor_type": "regex",
-      "converters": [
-        {
-          "type": "csv",
-          "config": {
-            "column_header": "RuleNumber,SubRuleNumber,Anchor,Tracker,Interface,Reason,Action,Direction,IPVersion,TOS,ECN,TTL,ID,Offset,Flags,ProtocolID,Protocol,Length,SourceIP,DestIP,ICMP_Type,ICMP_DestIP,ICMP_MTU"
-          }
-        }
-      ],
-      "order": 0,
-      "cursor_strategy": "copy",
-      "source_field": "message",
-      "target_field": "FilterData",
-      "extractor_config": {
-        "regex_value": "^filterlog:\\s+(.*)$"
-      },
-      "condition_type": "regex",
-      "condition_value": "^filterlog:\\s+.*,(in|out),4,.*,icmp,.*,needfrag,.*$"
-    },
-	
-	
-    {
-      "title": "pfSense filterlog: IPv4 ICMP TStamp",
-      "extractor_type": "regex",
-      "converters": [
-        {
-          "type": "csv",
-          "config": {
-            "column_header": "RuleNumber,SubRuleNumber,Anchor,Tracker,Interface,Reason,Action,Direction,IPVersion,TOS,ECN,TTL,ID,Offset,Flags,ProtocolID,Protocol,Length,SourceIP,DestIP,ICMP_Type,ICMP_ID,ICMP_Sequence"
-          }
-        }
-      ],
-      "order": 0,
-      "cursor_strategy": "copy",
-      "source_field": "message",
-      "target_field": "FilterData",
-      "extractor_config": {
-        "regex_value": "^filterlog:\\s+(.*)$"
-      },
-      "condition_type": "regex",
-      "condition_value": "^filterlog:\\s+.*,(in|out),4,.*,icmp,.*,tstamp,.*$"
-    },
-	
-	
-    {
-      "title": "pfSense filterlog: IPv4 ICMP TStamp Reply",
-      "extractor_type": "regex",
-      "converters": [
-        {
-          "type": "csv",
-          "config": {
-            "column_header": "RuleNumber,SubRuleNumber,Anchor,Tracker,Interface,Reason,Action,Direction,IPVersion,TOS,ECN,TTL,ID,Offset,Flags,ProtocolID,Protocol,Length,SourceIP,DestIP,ICMP_Type,ICMP_ID,ICMP_Sequence,ICMP_otime,ICMP_rtime,ICMP_ttime"
-          }
-        }
-      ],
-      "order": 0,
-      "cursor_strategy": "copy",
-      "source_field": "message",
-      "target_field": "FilterData",
-      "extractor_config": {
-        "regex_value": "^filterlog:\\s+(.*)$"
-      },
-      "condition_type": "regex",
-      "condition_value": "^filterlog:\\s+.*,(in|out),4,.*,icmp,.*,tstampreply,.*$"
-    },
-	
-	
-    {
-      "title": "pfSense filterlog: IPv4 ICMP Default",
-      "extractor_type": "regex",
-      "converters": [
-        {
-          "type": "csv",
-          "config": {
-            "column_header": "RuleNumber,SubRuleNumber,Anchor,Tracker,Interface,Reason,Action,Direction,IPVersion,TOS,ECN,TTL,ID,Offset,Flags,ProtocolID,Protocol,Length,SourceIP,DestIP,ICMP_Type,ICMP_Description"
-          }
-        }
-      ],
-      "order": 0,
-      "cursor_strategy": "copy",
-      "source_field": "message",
-      "target_field": "FilterData",
-      "extractor_config": {
-        "regex_value": "^filterlog:\\s+(.*)$"
-      },
-      "condition_type": "regex",
-      "condition_value": "^filterlog:\\s+.*,(in|out),4,.*,icmp,.*,(?!(request|reply|unreachproto|unreachport|unreach|timexceed|paramprob|redirect|maskreply|needfrag|tstamp|tstampreply)),.*$"
+      "condition_value": "^filterlog:\\s+.*,(in|out),6,.*,[uU][dD][pP],.*$"
     }
   ],
-  "version": "2.2.0-SNAPSHOT"
+  "version": "2.4.4_p2"
 }


### PR DESCRIPTION
Fields for different protocols and versions seem to have been normalized to some extend.
Need to figure out ICMP still but at least IPv4+6 TCP+UDP seem to work.